### PR TITLE
New keyboard shortcuts

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -42,8 +42,8 @@ set winminheight=0
 " Bend vim features and behaviors to our wishes. 
 "
 
-" for mistyping :w as :W
-command! W :w
+" Write with superuser permissions using :W command
+command W w !sudo tee % > /dev/null
 
 "
 " Command-mode completion

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -73,3 +73,23 @@ vnoremap <silent> <C-S> <ESC>:w<CR>i
 " Ctrl+Backspace, Ctrl+Delete word deletion
 inoremap <silent> <C-Backspace> <ESC><right>dbi
 inoremap <silent> <C-Delete>    <ESC><right>dwi
+
+" Tab navigation with Ctrl + Tabnum
+ino <silent> <C-1> <ESC>:tabfirst<CR>
+nno <silent> <C-1> <ESC>:tabfirst<CR>
+ino <silent> <C-2> <ESC>2gt
+nno <silent> <C-2> <ESC>2gt
+ino <silent> <C-3> <ESC>3gt
+nno <silent> <C-3> <ESC>3gt
+ino <silent> <C-4> <ESC>4gt
+nno <silent> <C-4> <ESC>4gt
+ino <silent> <C-5> <ESC>5gt
+nno <silent> <C-5> <ESC>5gt
+ino <silent> <C-6> <ESC>6gt
+nno <silent> <C-6> <ESC>6gt
+ino <silent> <C-7> <ESC>7gt
+nno <silent> <C-7> <ESC>7gt
+ino <silent> <C-8> <ESC>8gt
+nno <silent> <C-8> <ESC>8gt
+ino <silent> <C-9> <ESC>:tablast<CR>
+nno <silent> <C-9> <ESC>:tablast<CR>

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -11,43 +11,43 @@ inoremap <up> <nop>
 inoremap <down> <nop>
 inoremap <left> <nop>
 inoremap <right> <nop>
-nnoremap j gj
-nnoremap k gk
+nnoremap <silent> j gj
+nnoremap <silent> k gk
 
 " Remembering the line offset of a mark should be the norm
 nnoremap ' `
 nnoremap ` '
 
 " Indent using tabs (while in visual mode) 
-vnoremap <tab>       >gv
-vnoremap <s-tab>     <gv
-vnoremap <           <gv
-vnoremap >           >gv
+vnoremap <silent> <tab>       >gv
+vnoremap <silent> <s-tab>     <gv
+vnoremap <silent> <           <gv
+vnoremap <silent> >           >gv
 
 " Search only in the selected block (visual mode) 
-vnoremap / <esc>/\%V
+vnoremap <silent> / <esc>/\%V
 
 " Buffer horizontal traversal using C-j and C-k 
-nnoremap <C-j> <C-w>j
-nnoremap <C-k> <C-w>k
+nnoremap <silent> <C-j> <C-w>j
+nnoremap <silent> <C-k> <C-w>k
 
 " Tabs uses c-l and c-h
-map <C-h> <esc>:tabprevious<cr>
-map <C-l> <esc>:tabnext<cr>
+map <silent> <C-h> <esc>:tabprevious<cr>
+map <silent> <C-l> <esc>:tabnext<cr>
 
 " Easy buffer navigation with Mac option keys
 " opt-j, opt-h, opt-k, opt-l , respectively
-map <leader>vw <C-w>v<C-w>l
-map <leader>hw <C-w>s<C-w>l
-map <leader>++ 100<C-w>+<Cr>
-map <leader>== <C-w>=<Cr>
+map <silent> <leader>vw <C-w>v<C-w>l
+map <silent> <leader>hw <C-w>s<C-w>l
+map <silent> <leader>++ 100<C-w>+<Cr>
+map <silent> <leader>== <C-w>=<Cr>
 
 " Toggle line-numbering
 nn <leader>n <esc>:set number! number?<cr>
 
 " Nerd Tree
-nmap <leader>o :NERDTreeToggle<cr>
-nmap <leader>O :NERDTreeFind<cr>
+nmap <silent> <leader>o :NERDTreeToggle<cr>
+nmap <silent> <leader>O :NERDTreeFind<cr>
 
 " Omni autocomplete
 inoremap <Nul> <C-x><C-o>

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -59,3 +59,11 @@ inoremap <Nul> <C-x><C-o>
 nnoremap <silent> ,p "+p
 nnoremap <silent> ,P "+P
 nnoremap <silent> ,y "+yy
+
+" Common combinations with Ctrl-key goes here
+
+" Save file by Ctrl+S
+inoremap <silent> <C-S> <ESC>:w<CR>i
+nnoremap <silent> <C-S> <ESC>:w<CR>i
+vnoremap <silent> <C-S> <ESC>:w<CR>i
+

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -35,6 +35,9 @@ nnoremap <silent> <C-k> <C-w>k
 map <silent> <C-h> <esc>:tabprevious<cr>
 map <silent> <C-l> <esc>:tabnext<cr>
 
+" Open new tab pushing ,t
+nnoremap <silent> ,t <ESC>:tabnew<CR>
+
 " Easy buffer navigation with Mac option keys
 " opt-j, opt-h, opt-k, opt-l , respectively
 map <silent> <leader>vw <C-w>v<C-w>l

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -51,3 +51,8 @@ nmap <silent> <leader>O :NERDTreeFind<cr>
 
 " Omni autocomplete
 inoremap <Nul> <C-x><C-o>
+"
+" Easy copy-paste from system clipboard
+nnoremap <silent> ,p "+p
+nnoremap <silent> ,P "+P
+nnoremap <silent> ,y "+yy

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -60,6 +60,9 @@ nnoremap <silent> ,p "+p
 nnoremap <silent> ,P "+P
 nnoremap <silent> ,y "+yy
 
+" Smart home (go to real start of line)
+nnoremap <silent> <Home> g^
+
 " Common combinations with Ctrl-key goes here
 
 " Save file by Ctrl+S

--- a/vimrc-keymaps
+++ b/vimrc-keymaps
@@ -67,3 +67,6 @@ inoremap <silent> <C-S> <ESC>:w<CR>i
 nnoremap <silent> <C-S> <ESC>:w<CR>i
 vnoremap <silent> <C-S> <ESC>:w<CR>i
 
+" Ctrl+Backspace, Ctrl+Delete word deletion
+inoremap <silent> <C-Backspace> <ESC><right>dbi
+inoremap <silent> <C-Delete>    <ESC><right>dwi


### PR DESCRIPTION
1. Added <silent> flag before most of keyboard mappings to reduce flickering in your status bar
2. Replaced :W -> :w with command which would write file as superuser, which is handy if you forget to `sudo vim smth`
3. Other keyboard shortcuts are pretty straightforward. I find it handy to have Ctrl+[smth] ones, but you may consider them as not a "vim-way".
